### PR TITLE
New Butcher tableaux of some explicit Runge-Kutta for the sdm plugin

### DIFF
--- a/plugins/sdm/sdm/explicit_rungekutta/ExplicitRungeKutta.cpp
+++ b/plugins/sdm/sdm/explicit_rungekutta/ExplicitRungeKutta.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2011 von Karman Institute for Fluid Dynamics, Belgium
+// Copyright (C) 2010-2012 von Karman Institute for Fluid Dynamics, Belgium
 //
 // This software is distributed under the terms of the
 // GNU Lesser General Public License version 3 (LGPLv3).
@@ -239,14 +239,14 @@ common::ComponentBuilder < ExplicitRungeKutta, ExplicitRungeKuttaBase, LibExplic
 ExplicitRungeKutta::ExplicitRungeKutta ( const std::string& name ) : ExplicitRungeKuttaBase(name)
 {
   options().add("order", 4)
-      .description("Order of the Runge-Kutta integration (default = RK4)\n"
-                   "NOTE: This overrides any existing butcher-tableau")
+      .description("Order of the Runge-Kutta integration (default = RK44)\n"
+                   "NOTE: This overrides any existing Butcher tableau")
       .pretty_name("RK order")
       .attach_trigger( boost::bind( &ExplicitRungeKutta::config_butcher_tableau, this ) )
       .mark_basic();
 
   m_butcher = create_component<ButcherTableau>("butcher_tableau");
-  m_butcher->set( butcher_tableau::ClassicRK4() );
+  m_butcher->set( butcher_tableau::ClassicRK44() );
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -258,21 +258,24 @@ void ExplicitRungeKutta::config_butcher_tableau()
   const Uint order = options().value<Uint>("order");
   switch (order)
   {
-    case 1: // set to Forward Euler
+    case 1: // set to forward Euler
       m_butcher->set( butcher_tableau::ForwardEuler() );
       break;
-    case 2: // Heun method
-      m_butcher->set( butcher_tableau::Heun() );
+    case 2: // 2-stage 2nd-order method
+      m_butcher->set( butcher_tableau::Heun2() );
       break;
-    case 3: // RK3
-      m_butcher->set( butcher_tableau::RK3() );
+    case 3: // Classic RK33
+      m_butcher->set( butcher_tableau::ClassicRK33() );
       break;
-    case 4: // Classic RK4
-      m_butcher->set( butcher_tableau::ClassicRK4() );
+    case 4: // Classic RK44
+      m_butcher->set( butcher_tableau::ClassicRK44() );
+      break;
+    case 5: // RKF65
+      m_butcher->set( butcher_tableau::RKF65() );
       break;
     default:
-      CFwarn << "Cannot configure order " << order << ". Using ClassicRK4 instead." << CFendl;
-      m_butcher->set( butcher_tableau::ClassicRK4() );
+      CFwarn << "Cannot configure order " << order << ". Using ClassicRK44 instead." << CFendl;
+      m_butcher->set( butcher_tableau::ClassicRK44() );
       break;
   }
   CFinfo << "Used Butcher tableau:\n" << m_butcher->str() << CFendl;

--- a/plugins/sdm/sdm/explicit_rungekutta/ExplicitRungeKutta.hpp
+++ b/plugins/sdm/sdm/explicit_rungekutta/ExplicitRungeKutta.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2011 von Karman Institute for Fluid Dynamics, Belgium
+// Copyright (C) 2010-2012 von Karman Institute for Fluid Dynamics, Belgium
 //
 // This software is distributed under the terms of the
 // GNU Lesser General Public License version 3 (LGPLv3).
@@ -6,6 +6,7 @@
 
 /// @file sdm/explicit_rungekutta/ExplicitRungeKutta.hpp
 /// @author Willem Deconinck
+/// @author Matteo Parsani
 ///
 /// This file includes the ExplicitRungeKuttaBase component class,
 /// defining the Explicit Runge Kutta scheme,
@@ -37,7 +38,7 @@ namespace explicit_rungekutta {
 
 /// @brief Runge-Kutta integration method
 ///
-/// Standard Explicit Runge-Kutta integration using butcher tableau coefficients
+/// Standard Explicit Runge-Kutta integration using Butcher tableau coefficients
 /// @verbatim
 /// 0  |
 /// c2 | a21
@@ -107,12 +108,13 @@ private: // data
 /// @brief Explicit Runge Kutta integration method
 ///
 /// Configuring the option "order" automatically preconfigures some default
-/// Butcher tableau's:
-/// - order = 1 --> Forward Euler
-/// - order = 2 --> Heun
-/// - order = 3 --> RK3
-/// - order = 4 --> Classic RK4
-/// If nothing is configured, Classic RK4 is assumed.
+/// Butcher tableaux:
+/// - order = 1 --> forward Euler (ForwardEuler)
+/// - order = 2 --> 2-stage 2nd-order Heun method (Heun2)
+/// - order = 3 --> classic 3-stage 3rd-order Runge-Kutta method (ClassicRK33)
+/// - order = 4 --> classic 4-stage 4th-order Runge-Kutta method (ClassicRK44)
+/// - order = 5 --> 6-stage 5th-order Runge-Kutta-Fehlberg method (from the Fehlberg pair) (RKF65)
+/// If nothing is configured, ClassicRK44 is assumed.
 /// @author Willem Deconinck
 class sdm_explicit_rungekutta_API ExplicitRungeKutta : public ExplicitRungeKuttaBase {
 
@@ -138,7 +140,7 @@ private: // functions
 ///
 /// The typename of the component will be:
 /// "cf3.sdm.explicit_rungekutta.<name>"  with <name> to be replaced by
-/// the name of the Butcher tableau. For a list of Butcher tableau's, check
+/// the name of the Butcher tableau. For a list of Butcher tableaux, check
 /// sdm/explicit_rungekutta/Types.hpp
 /// @author Willem Deconinck
 template <typename BUTCHER_TABLEAU>

--- a/plugins/sdm/sdm/explicit_rungekutta/Types.cpp
+++ b/plugins/sdm/sdm/explicit_rungekutta/Types.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2011 von Karman Institute for Fluid Dynamics, Belgium
+// Copyright (C) 2010-2012 von Karman Institute for Fluid Dynamics, Belgium
 //
 // This software is distributed under the terms of the
 // GNU Lesser General Public License version 3 (LGPLv3).
@@ -21,20 +21,25 @@ using namespace boost::assign;
 
 // Register the component types in the common::Action factory, so they can be
 // dynamically created
-ComponentBuilder < ForwardEuler, common::Action, LibExplicitRungeKutta > ForwardEuler_Builder;
-ComponentBuilder < Heun,         common::Action, LibExplicitRungeKutta > Heun_Builder;
-ComponentBuilder < RK3,          common::Action, LibExplicitRungeKutta > RK3_Builder;
-ComponentBuilder < ClassicRK4,   common::Action, LibExplicitRungeKutta > ClassicRK4_Builder;
+ComponentBuilder < ForwardEuler,  common::Action, LibExplicitRungeKutta > ForwardEuler_Builder;
+ComponentBuilder < Heun2,         common::Action, LibExplicitRungeKutta > Heun2_Builder;
+ComponentBuilder < MidPoint,      common::Action, LibExplicitRungeKutta > MidPoint_Builder;
+ComponentBuilder < ClassicRK33,   common::Action, LibExplicitRungeKutta > ClassicRK33_Builder;
+ComponentBuilder < Heun3,         common::Action, LibExplicitRungeKutta > Heun3_Builder;
+ComponentBuilder < ClassicRK44,   common::Action, LibExplicitRungeKutta > ClassicRK44_Builder;
+ComponentBuilder < SSPRK54,       common::Action, LibExplicitRungeKutta > SSPRK54_Builder;
+ComponentBuilder < RK65,          common::Action, LibExplicitRungeKutta > RK65_Builder;
+ComponentBuilder < RKF65,    common::Action, LibExplicitRungeKutta > RKF65_Builder;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Definitions of the Butcher tableau's.
+// Definitions of the Butcher tableaux.
 
 namespace butcher_tableau {
 
 
 
-
+// 1st-order methods
 ForwardEuler::ForwardEuler()
 {
   order     = 1;
@@ -48,8 +53,8 @@ ForwardEuler::ForwardEuler()
 
 
 
-
-Heun::Heun()
+// 2nd-order methods
+Heun2::Heun2()
 {
   order     = 2;
   nb_stages = 2;
@@ -64,7 +69,22 @@ Heun::Heun()
 
 
 
-RK3::RK3()
+MidPoint::MidPoint()
+{
+  order     = 2;
+  nb_stages = 2;
+
+  a +=  0.,    0.,
+        1./2., 0.;
+
+  b +=  0., 1.;
+}
+
+
+
+
+// 3rd-order methods
+ClassicRK33::ClassicRK33()
 {
   order     = 3;
   nb_stages = 3;
@@ -80,7 +100,23 @@ RK3::RK3()
 
 
 
-ClassicRK4::ClassicRK4()
+Heun3::Heun3()
+{
+  order     = 3;
+  nb_stages = 3;
+
+  a +=  0.,    0.,    0.,
+        1./3., 0.,    0.,
+        0.,    2./3., 0.; 
+
+  b +=  1./4., 0., 3./4.;
+}
+
+
+
+
+// 4th-order methods
+ClassicRK44::ClassicRK44()
 {
   order     = 4;
   nb_stages = 4;
@@ -92,6 +128,64 @@ ClassicRK4::ClassicRK4()
 
   b +=  1./6., 1./3., 1./3., 1./6.;
 }
+
+
+
+
+
+SSPRK54::SSPRK54()
+{
+  order     = 4;
+  nb_stages = 4;
+
+  a +=  0.,               0.,               0.,               0.,               0.,
+        0.39175222700392, 0.,               0.,               0.,               0.,
+        0.21766909633821, 0.36841059262959, 0.,               0.,               0.,
+        0.08269208670950, 0.13995850206999, 0.25189177424738, 0.,               0.,
+        0.06796628370320, 0.11503469844438, 0.20703489864929, 0.54497475021237, 0.;
+
+  b +=  0.14681187618661, 0.24848290924556, 0.10425883036650, 0.27443890091960, 0.22600748319395;
+}
+
+
+
+
+
+// 5th-order methods
+RK65::RK65()
+{
+  order     = 5;
+  nb_stages = 6;
+
+  a +=  0.,     0.,      0.,    0.,      0.,    0.,
+        1./4.,  0.,      0.,    0.,      0.,    0.,
+        1./8,   1./8.,   0.,    0.,      0.,    0.,
+        0.,     0.,      1./2., 0.,      0.,    0.,
+        3./16., -3./8.,  3./8., 9./16.,  0.,    0.,
+        -3./7., 8./7.,   6./7., -12./7., 8./7., 0.;
+
+  b +=  7./90., 0., 32./90., 12./90., 32./90., 7./9.;
+}
+
+
+
+
+
+RKF65::RKF65()
+{
+  order     = 5;
+  nb_stages = 6;
+
+  a +=  0.,          0.,           0.,           0.,           0.,      0.,
+        1./4.,       0.,           0.,           0.,           0.,      0.,
+        3./32.,      9./32.,       0.,           0.,           0.,      0.,
+        1932./2197., -7200./2197., 7296./2197.,  0.,           0.,      0.,
+        439./216.,   -8.,          3680./513.,   -845./4104.,  0.,      0.,
+        -8./27.,     2.,           -3544./2565., 1859./4104., -11./40., 0.;
+
+  b +=  16./135., 0., 6656./12825., 28561./56430.,-9./50.,2./55.;
+}
+
 
 
 

--- a/plugins/sdm/sdm/explicit_rungekutta/Types.hpp
+++ b/plugins/sdm/sdm/explicit_rungekutta/Types.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2011 von Karman Institute for Fluid Dynamics, Belgium
+// Copyright (C) 2010-2012 von Karman Institute for Fluid Dynamics, Belgium
 //
 // This software is distributed under the terms of the
 // GNU Lesser General Public License version 3 (LGPLv3).
@@ -6,8 +6,9 @@
 
 /// @file sdm/explicit_rungekutta/Types.hpp
 /// @author Willem Deconinck
+/// @author Matteo Parsani
 ///
-/// This file defines several Butcher-tableau's,
+/// This file defines several Butcher tableaux,
 /// and corresonding Explicit Runge-Kutta methods
 
 #include "sdm/explicit_rungekutta/ExplicitRungeKutta.hpp"
@@ -18,16 +19,27 @@ namespace explicit_rungekutta {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Forward declarations of Butcher tableau's.
+// Forward declarations of Butcher tableaux.
 // The declarations are below
 
-/// @brief Preconfigured butcher tableau's
+/// @brief Preconfigured Butcher tableaux
+///
+/// The acronym RK is used to indicate a Runge-Kutta method
+/// The acronym RKF is used to indicate a Runge-Kutta-Fehlberg method
+/// The acronym SSP is used to indicate a strong stability preserving method 
+/// RK is always followed by two integer numbers: number of stages and order
+/// of the method
 namespace butcher_tableau
 {
   struct ForwardEuler;
-  struct Heun;
-  struct RK3;
-  struct ClassicRK4;
+  struct Heun2;
+  struct MidPoint;
+  struct ClassicRK33;
+  struct Heun3;
+  struct ClassicRK44;
+  struct SSPRK54;
+  struct RK65;
+  struct RKF65;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -36,17 +48,32 @@ namespace butcher_tableau
 // Their type-name = "cf3.sdm.explicit_rungekutta.<butcher_tableau>", with
 // <butcher_tableau> the name of the Butcher Tableau
 
-/// @brief Forward Euler time integration method
+/// @brief forward Euler time integration method
 typedef ExplicitRungeKuttaT<butcher_tableau::ForwardEuler> ForwardEuler;
 
-/// @brief Heun time integration method
-typedef ExplicitRungeKuttaT<butcher_tableau::Heun>         Heun;
+/// @brief 2-stage 2nd-order Heun time integration method
+typedef ExplicitRungeKuttaT<butcher_tableau::Heun2>        Heun2;
 
-/// @brief RK3 time integration method
-typedef ExplicitRungeKuttaT<butcher_tableau::RK3>          RK3;
+/// @brief MidPoint time integration method
+typedef ExplicitRungeKuttaT<butcher_tableau::MidPoint>     MidPoint;
 
-/// @brief Classic RK4 time integration method
-typedef ExplicitRungeKuttaT<butcher_tableau::ClassicRK4>   ClassicRK4;
+/// @brief Classic RK33 time integration method
+typedef ExplicitRungeKuttaT<butcher_tableau::ClassicRK33>  ClassicRK33;
+
+/// @brief 3-stage 3rd-order Heun time integration method
+typedef ExplicitRungeKuttaT<butcher_tableau::Heun3>        Heun3;
+
+/// @brief Classic RK44 time integration method
+typedef ExplicitRungeKuttaT<butcher_tableau::ClassicRK44>  ClassicRK44;
+
+/// @brief 5-stage 4th-order  SSPRK time integration method
+typedef ExplicitRungeKuttaT<butcher_tableau::SSPRK54>      SSPRK54;
+
+/// @brief 6-stage 5th-order RK time integration method
+typedef ExplicitRungeKuttaT<butcher_tableau::RK65>         RK65;
+
+/// @brief 6-stage 5th-order RKF time integration method
+typedef ExplicitRungeKuttaT<butcher_tableau::RKF65>        RKF65;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -57,7 +84,12 @@ namespace butcher_tableau {
 
 
 
-/// @brief Forward Euler Butcher tableau coefficients
+/// 1st-order methods
+/////////////////////
+
+/// @brief forward Euler Butcher tableau coefficients
+///
+/// This method is also known as explicit Euler method
 /// @verbatim
 /// 0 |
 /// ------
@@ -72,24 +104,52 @@ struct ForwardEuler : ButcherTableau::Coefficients
 
 
 
+/// 2nd-order methods
+/////////////////////
 
-/// @brief Heun Butcher tableau coefficients
+/// @brief Heun2 Butcher tableau coefficients
+/// 
+/// 2-stage 2nd-order Heun method
+/// @ref K. Heun: Neue methode zur approximativen integration der differentialgleichungen einer unabhangigen variable
+///      Z. Angew. Math. Phys., 45 (1900), 23–38
 /// @verbatim
 /// 0   |
 /// 2/3 | 2/3
 /// --------------
 ///     | 1/3  3/4
 /// @endverbatim
-struct Heun : ButcherTableau::Coefficients
+struct Heun2 : ButcherTableau::Coefficients
 {
-  static std::string name() { return "Heun"; }
-  Heun();
+  static std::string name() { return "Heun2"; }
+  Heun2();
 };
 
 
 
 
-/// @brief RK3 Butcher tableau coefficients
+/// @brief mid-point Butcher tableau coefficients
+/// @verbatim
+/// 0   |
+/// 1/2 | 1/2
+/// --------------
+///     | 0   1
+/// @endverbatim
+struct MidPoint : ButcherTableau::Coefficients
+{
+  static std::string name() { return "MidPoint"; }
+  MidPoint();
+};
+
+
+
+/// 3rd-order methods
+/////////////////////
+
+/// @brief classic RK33 Butcher tableau coefficients
+/// 
+/// 3-stage 3rd-order Kutta's method 
+/// @ref W. Kutta: Beitrag zur naherungsweisen integration totaler differentialgleichungen
+///      Z. Angew. Math. Phys., 46 (1901), 435–453
 /// @verbatim
 /// 0   |
 /// 1/2 | 1/2
@@ -97,17 +157,44 @@ struct Heun : ButcherTableau::Coefficients
 /// -------------------
 ///     | 1/6  2/3  1/6
 /// @endverbatim
-struct RK3 : ButcherTableau::Coefficients
+struct ClassicRK33 : ButcherTableau::Coefficients
 {
-  static std::string name() { return "RK3"; }
-  RK3();
+  static std::string name() { return "ClassicRK33"; }
+  ClassicRK33();
 };
 
 
 
 
+/// @brief Heun3 Butcher tableau coefficients
+///
+/// 3-stage 23rd-order Heun method
+/// @ref K. Heun: Neue methode zur approximativen integration der differentialgleichungen einer unabhangigen variable
+///      Z. Angew. Math. Phys., 45 (1900), 23–38
+/// @verbatim
+/// 0   |
+/// 1/3 | 1/3  
+/// 2/3 | 0    2/3
+/// -------------------
+///     | 1/4  0    3/4
+/// @endverbatim
+struct Heun3 : ButcherTableau::Coefficients
+{
+  static std::string name() { return "Heun3"; }
+  Heun3();
+};
 
-/// @brief Classic RK4 Butcher tableau coefficients
+
+
+
+/// 4th-order methods
+/////////////////////
+
+/// @brief classic RK44 Butcher tableau coefficients
+///
+/// 4-stage 4th-order Kutta's method 
+/// @ref W. Kutta: Beitrag zur naherungsweisen Integration totaler differentialgleichungen
+///      Z. Angew. Math. Phys., 46 (1901), 435–453
 /// @verbatim
 /// 0   |
 /// 1/2 | 1/2
@@ -116,10 +203,85 @@ struct RK3 : ButcherTableau::Coefficients
 /// ------------------------
 ///     | 1/6  1/3  1/3  1/6
 /// @endverbatim
-struct ClassicRK4 : ButcherTableau::Coefficients
+struct ClassicRK44 : ButcherTableau::Coefficients
 {
-  static std::string name() { return "ClassicRK4"; }
-  ClassicRK4();
+  static std::string name() { return "ClassicRK44"; }
+  ClassicRK44();
+};
+
+
+
+
+/// @brief  SSPRK54 Butcher tableau coefficients
+///
+/// Optimal 5-stage 4th-order SSPRK method
+/// @ref R. J. Spiteri and S. J. Ruuth: A new class of optimal high order strong stability preserving time discretization methods
+///      SIAM Journal of Numerical Analysis, 40 (2002), 469-491
+///      doi:10.1137/S0036142901389025
+/// @verbatim
+/// 0                |
+/// 0.39175222700392 | 0.39175222700392
+/// 0.58607968896780 | 0.21766909633821  0.36841059262959                
+/// 0.47454236302687 | 0.08269208670950  0.13995850206999  0.25189177424738
+/// 0.93501063100924 | 0.06796628370320  0.11503469844438  0.20703489864929  0.54497475021237
+/// -----------------------------------------------------------------------------------------------------------
+///                  | 0.14681187618661  0.24848290924556  0.10425883036650  0.27443890091960  0.22600748319395
+/// @endverbatim
+struct SSPRK54 : ButcherTableau::Coefficients
+{
+  static std::string name() { return "SSPRK54"; }
+  SSPRK54();
+};
+
+
+
+
+/// 5th-order methods
+/////////////////////
+
+/// @brief RK65 Butcher tableau coefficients
+///
+/// A 6-stage 5th-order RK method
+/// @ref J. C. Butcher: Numerical methods for ordinary differential equations
+//       John Wiley & Sons, Ltd
+/// @verbatim
+/// 0   |
+/// 1/4 | 1/4
+/// 1/4 | 1/8   1/8
+/// 1/2 | 0     0     1/2
+/// 3/4 | 3/16  -3/8  3/8    9/16
+/// 1   | -3/7  8/7   6/7    -12/7  8/7 
+/// ---------------------------------------------
+///     | 7/90  0     32/90  12/90  32/90  7/90
+/// @endverbatim
+struct RK65 : ButcherTableau::Coefficients
+{
+  static std::string name() { return "RK65"; }
+  RK65();
+};
+
+
+
+
+/// @brief RKF65 Butcher tableau coefficients
+///
+/// 6-stage 5th-order RKF method extracted form the RKF6(4)5 pair
+/// @ref E. Fehlberg. Low-order classical Runge-Kutta formulas with stepsize control and their application to some heat transfer
+///      Technical report, NASA TR R-315, National Aeronautics and Space Administration, Marshall Space Flight Center, Marshall, AL, 1969.
+/// @verbatim
+/// 0     |
+/// 1/4   | 1/4
+/// 3/8   | 3/32       9/32
+/// 12/13 | 1932/2197  -7200/2197  7296/2197
+/// 1     | 439/216    -8          3680/513    -845/4104
+/// 1/2   | -8/27      2           -3544/2565  1859/4104   -11/40 
+/// ----------------------------------------------------------------
+///       | 16/135,    0           6656/12825  28561/56430 -9/50  2/55
+/// @endverbatim
+struct RKF65 : ButcherTableau::Coefficients
+{
+  static std::string name() { return "RKF65"; }
+  RKF65();
 };
 
 


### PR DESCRIPTION
This pull request delivers new Butcher tableaux for the sdm plugin and renames some of the existing Runge-Kutta schemes available (for sdm).

I have compiled the sdm source code and I have run all the unit tests. Everything passes correctly.
